### PR TITLE
Add a binary_uuid type.

### DIFF
--- a/src/UuidBinaryType.php
+++ b/src/UuidBinaryType.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * This file is part of the Ramsey\Uuid\Doctrine library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Ben Ramsey <http://benramsey.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link https://packagist.org/packages/ramsey/uuid-doctrine Packagist
+ * @link https://github.com/ramsey/uuid-doctrine GitHub
+ */
+
+namespace Ramsey\Uuid\Doctrine;
+
+use InvalidArgumentException;
+use Ramsey\Uuid\Uuid;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * Field type mapping for the Doctrine Database Abstraction Layer (DBAL).
+ *
+ * UUID fields will be stored as a string in the database and converted back to
+ * the Uuid value object when querying.
+ */
+class UuidBinaryType extends Type
+{
+    /**
+     * @var string
+     */
+    const NAME = 'uuid_binary';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array                                     $fieldDeclaration
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getBinaryTypeDeclarationSQL(
+            array(
+                'length' => '16',
+                'fixed' => true,
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string|null                               $value
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        if ($value instanceof Uuid) {
+            return $value;
+        }
+
+        try {
+            $uuid = Uuid::fromBytes($value);
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailed($value, self::NAME);
+        }
+
+        return $uuid;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param Uuid|null                                 $value
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        if ($value instanceof Uuid || Uuid::isValid($value)) {
+            return hex2bin(str_replace('-', '', (string) $value));
+        }
+
+        throw ConversionException::conversionFailed($value, self::NAME);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     * @return boolean
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+}

--- a/tests/UuidBinaryTypeTest.php
+++ b/tests/UuidBinaryTypeTest.php
@@ -1,0 +1,129 @@
+<?php
+namespace Ramsey\Uuid\Doctrine;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use Ramsey\Uuid\Uuid;
+
+class UuidBinaryTypeTest extends \PHPUnit_Framework_TestCase
+{
+    private $platform;
+    private $type;
+
+    public static function setUpBeforeClass()
+    {
+        if (class_exists('Doctrine\\DBAL\\Types\\Type')) {
+            Type::addType('uuid_binary', 'Ramsey\Uuid\Doctrine\UuidBinaryType');
+        }
+    }
+
+    protected function setUp()
+    {
+        $this->platform = $this->getPlatformMock();
+        $this->platform->expects($this->any())
+            ->method('getBinaryTypeDeclarationSQL')
+            ->will($this->returnValue('DUMMYBINARY(16)'));
+
+        $this->type = Type::getType('uuid_binary');
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToDatabaseValue
+     */
+    public function testUuidConvertsToDatabaseValue()
+    {
+        $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
+
+        $expected = hex2bin('ff6f8cb0c57d11e19b210800200c9a66');
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToDatabaseValue
+     */
+    public function testInvalidUuidConversionForDatabaseValue()
+    {
+        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
+        $this->type->convertToDatabaseValue('abcdefg', $this->platform);
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToDatabaseValue
+     */
+    public function testNullConversionForDatabaseValue()
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToPHPValue
+     */
+    public function testUuidConvertsToPHPValue()
+    {
+        $uuid = $this->type->convertToPHPValue(hex2bin('ff6f8cb0c57d11e19b210800200c9a66'), $this->platform);
+        $this->assertInstanceOf('Ramsey\Uuid\Uuid', $uuid);
+        $this->assertEquals('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToPHPValue
+     */
+    public function testInvalidUuidConversionForPHPValue()
+    {
+        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
+        $this->type->convertToPHPValue('abcdefg', $this->platform);
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToPHPValue
+     */
+    public function testNullConversionForPHPValue()
+    {
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToPHPValue
+     */
+    public function testReturnValueIfUuidForPHPValue()
+    {
+        $uuid = Uuid::uuid4();
+        $this->assertSame($uuid, $this->type->convertToPHPValue($uuid, $this->platform));
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::getName
+     */
+    public function testGetName()
+    {
+        $this->assertEquals('uuid_binary', $this->type->getName());
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::getSqlDeclaration
+     */
+    public function testGetGuidTypeDeclarationSQL()
+    {
+        $this->assertEquals('DUMMYBINARY(16)', $this->type->getSqlDeclaration(array('length' => 36), $this->platform));
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::requiresSQLCommentHint
+     */
+    public function testRequiresSQLCommentHint()
+    {
+        $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getPlatformMock()
+    {
+        return $this->getMockBuilder('Doctrine\DBAL\Platforms\AbstractPlatform')
+            ->setMethods(array('getBinaryTypeDeclarationSQL'))
+            ->getMockForAbstractClass();
+    }
+}


### PR DESCRIPTION
This saves the uuid in a BINARY(16) field instead of a VARCHAR field.
This will improve performance a lot when dealing with lots of data.

Note that it has one drawback: your uuid's arent' readable in your DB anymore, which makes manual querying, thus without doctrine, a lot harder.

See https://github.com/ramsey/uuid/issues/63