### PR TITLE
Loosen doctrine/dbal version requirement to ~2.3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=5.4",
         "ramsey/uuid": "^3.0",
-        "doctrine/dbal": "^2.5"
+        "doctrine/dbal": "^2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",


### PR DESCRIPTION
The Type definitions work perfectly with Doctrine DBAL version 2.3 and up. DBAL 2.3.0 introduced  ``Type::requiresSQLCommentHint()`` so probably does not work with previous versions.

I think it would be important to loosen up the version requirement because current Symfony (2.7 LTS) and the next release (2.8 LTS) are incompatible with this package since Symfony specifically requires DBAL <2.5.