### PR TITLE
Fix converting uuid string to binary uuid

### DIFF
--- a/src/UuidBinaryType.php
+++ b/src/UuidBinaryType.php
@@ -85,11 +85,17 @@ class UuidBinaryType extends Type
             return null;
         }
 
-        if ($value instanceof Uuid || Uuid::isValid($value)) {
+        if ($value instanceof Uuid) {
             return $value->getBytes();
         }
 
-        throw ConversionException::conversionFailed($value, self::NAME);
+        try {
+            $uuid = Uuid::fromString($value);
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailed($value, self::NAME);
+        }
+
+        return $uuid->getBytes();
     }
 
     /**

--- a/tests/UuidBinaryTypeTest.php
+++ b/tests/UuidBinaryTypeTest.php
@@ -43,6 +43,19 @@ class UuidBinaryTypeTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToDatabaseValue
      */
+    public function testStringUuidConvertsToDatabaseValue()
+    {
+        $uuid = 'ff6f8cb0-c57d-11e1-9b21-0800200c9a66';
+
+        $expected = hex2bin('ff6f8cb0c57d11e19b210800200c9a66');
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToDatabaseValue
+     */
     public function testInvalidUuidConversionForDatabaseValue()
     {
         $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');


### PR DESCRIPTION
There was a bug when a UUID string had to be stored as a binary UUID database value.