### PR TITLE
Add UUID generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ This project adheres to a [Contributor Code of Conduct](https://github.com/ramse
 * [Ben Ramsey](https://github.com/ramsey) - original author and maintainer
 * [Marijn Huizendveld](https://github.com/marijn) - contributor, author of UUID type definition for Doctrine DBAL
 * [Thibaud Fabre](https://github.com/aztech-dev) - contributor, lead developer for version 3.0.0 re-architecture
+* [Jaik Dean](https://github.com/jaikdean) - contributor, author of UUID generator for Doctrine ORM
 
 ## Communication Channels
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ class Product
      * @Id
      * @Column(type="uuid")
      * @GeneratedValue(strategy="CUSTOM")
-     * @CustomIdGenerator(class="AppBundle\ORM\UuidGenerator")
+     * @CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
      */
     protected $id;
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,8 @@ $entityManager->getConnection()->getDatabasePlatform()->registerDoctrineTypeMapp
 ```
 
 Then, in your models, you may annotate properties by setting the `@Column`
-type to `uuid`. Depending on your database engine, you may not be able to
-auto-generate a UUID when inserting into the database, but this isn't a problem;
-in your model's constructor (or elsewhere, depending on how you create instances
-of your model), generate a `Ramsey\Uuid\Uuid` object for the property. Doctrine
-will handle the rest.
-
-For example, here we annotate an `@Id` column with the `uuid` type, and in the
-constructor, we generate a version 4 UUID to store for this entity.
+type to `uuid`, and defining a custom generator of `Ramsey\Uuid\UuidGenerator`.
+Doctrine will handle the rest.
 
 ``` php
 /**
@@ -57,14 +51,10 @@ class Product
      *
      * @Id
      * @Column(type="uuid")
-     * @GeneratedValue(strategy="NONE")
+     * @GeneratedValue(strategy="CUSTOM")
+     * @CustomIdGenerator(class="AppBundle\ORM\UuidGenerator")
      */
     protected $id;
-
-    public function __construct()
-    {
-        $this->id = \Ramsey\Uuid\Uuid::uuid4();
-    }
 
     public function getId()
     {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "phpunit/phpunit": "^4.7|^5.0",
         "squizlabs/php_codesniffer": "^2.3",
         "jakub-onderka/php-parallel-lint": "^0.9.0",
-        "satooshi/php-coveralls": "^0.6.1"
+        "satooshi/php-coveralls": "^0.6.1",
+        "doctrine/orm": "^2.5"
     },
     "autoload": {
         "psr-4": {"Ramsey\\Uuid\\Doctrine\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,13 @@
     "require": {
         "php": ">=5.4",
         "ramsey/uuid": "^3.0",
-        "doctrine/dbal": "^2.5"
+        "doctrine/orm": "^2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7|^5.0",
         "squizlabs/php_codesniffer": "^2.3",
         "jakub-onderka/php-parallel-lint": "^0.9.0",
-        "satooshi/php-coveralls": "^0.6.1",
-        "doctrine/orm": "^2.5"
+        "satooshi/php-coveralls": "^0.6.1"
     },
     "autoload": {
         "psr-4": {"Ramsey\\Uuid\\Doctrine\\": "src/"}

--- a/src/UuidGenerator.php
+++ b/src/UuidGenerator.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the ramsey/uuid-doctrine library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Ben Ramsey <http://benramsey.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link https://packagist.org/packages/ramsey/uuid-doctrine Packagist
+ * @link https://github.com/ramsey/uuid-doctrine GitHub
+ */
+
+namespace Ramsey\Uuid\Doctrine;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\AbstractIdGenerator;
+
+/**
+ * UUID generator for the Doctrine ORM.
+ */
+class UuidGenerator extends AbstractIdGenerator
+{
+    /**
+     * Generate an identifier
+     *
+     * @param \Doctrine\ORM\EntityManager  $em
+     * @param \Doctrine\ORM\Mapping\Entity $entity
+     * @return Ramsey\Uuid\Uuid
+     */
+    public function generate(EntityManager $em, $entity)
+    {
+        return \Ramsey\Uuid\Uuid::uuid4();
+    }
+}

--- a/tests/TestEntityManager.php
+++ b/tests/TestEntityManager.php
@@ -1,0 +1,14 @@
+<?php
+namespace Ramsey\Uuid\Doctrine;
+
+/**
+ * The Doctrine ORM defines \Doctrine\ORM\EntityManager::__construct as a
+ * protected method, meaning PHPUnit can’t mock it. We need to extend the class
+ * to make this method public for testing.
+ */
+class TestEntityManager extends \Doctrine\ORM\EntityManager
+{
+    public function __construct()
+    {
+    }
+}

--- a/tests/UuidGeneratorTest.php
+++ b/tests/UuidGeneratorTest.php
@@ -1,0 +1,30 @@
+<?php
+namespace Ramsey\Uuid\Doctrine;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use Ramsey\Uuid\Uuid;
+
+class UuidGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    private $em;
+    private $entity;
+    private $generator;
+
+    protected function setUp()
+    {
+        $this->em = new TestEntityManager();
+        $this->entity = new \Doctrine\ORM\Mapping\Entity();
+        $this->generator = new UuidGenerator();
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidGenerator::generate
+     */
+    public function testUuidGeneratorGenerates()
+    {
+        $uuid = $this->generator->generate($this->em, $this->entity);
+
+        $this->assertInstanceOf('Ramsey\Uuid\Uuid', $uuid);
+    }
+}


### PR DESCRIPTION
This PR adds a Doctrine ORM UUID identifier generator, removing the need to manually generate a UUID in the entity's constructor. I've updated the documentation accordingly.