### PR TITLE
Remove doctrine mapping register advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ the following in your bootstrap:
 
 ``` php
 \Doctrine\DBAL\Types\Type::addType('uuid', 'Ramsey\Uuid\Doctrine\UuidType');
-$entityManager->getConnection()->getDatabasePlatform()->registerDoctrineTypeMapping('uuid', 'uuid');
 ```
 
 Then, in your models, you may annotate properties by setting the `@Column`


### PR DESCRIPTION
It doesn't appear that you need to do this to have the new type registered. As long as the class is defined in the @CustomIdGenerator config, everything appears to work fine.

This is quite handy, as it means you can set everything up without actually instantiating an entity manager. This was useful for me as I was using a registry that handle a number of EntityManagers and only had to declare the new type once statically, and once again where I wanted to use it in my annotations.

I'm using Doctrine DBAL v2.5.4, not 100% sure about BC on this.
