### PR TITLE
Add type to store UUIDv1 in MySQL-optimized format

### DIFF
--- a/src/UuidBinaryOrderedTimeType.php
+++ b/src/UuidBinaryOrderedTimeType.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Ramsey\Uuid\Doctrine;
+
+use InvalidArgumentException;
+use Ramsey\Uuid\Codec\OrderedTimeCodec;
+use Ramsey\Uuid\Uuid;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Ramsey\Uuid\UuidFactory;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * Field type mapping for the Doctrine Database Abstraction Layer (DBAL).
+ *
+ * UUID fields will be stored as a binary in the database and converted back to
+ * the Uuid value object when querying.
+ */
+class UuidBinaryOrderedTimeType extends Type
+{
+    /**
+     * @var string
+     */
+    const NAME = 'uuid_binary_ordered_time';
+
+    /**
+     * @var UuidFactory|null
+     */
+    private $factory;
+
+    /**
+     * @var OrderedTimeCodec
+     */
+    private $codec;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array                                     $fieldDeclaration
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getBinaryTypeDeclarationSQL(
+            array(
+                'length' => '16',
+                'fixed' => true,
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string|null                               $value
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        if ($value instanceof Uuid) {
+            return $value;
+        }
+
+        try {
+            return $this->decode($value);
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailed($value, self::NAME);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param UuidInterface|null                           $value
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        if ($value instanceof Uuid) {
+            return $this->encode($value);
+        }
+
+        try {
+            $uuid = $this->getUuidFactory()->fromString($value);
+        } catch (InvalidArgumentException $e) {
+            throw ConversionException::conversionFailed($value, self::NAME);
+        }
+
+        return $this->encode($uuid);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     * @return boolean
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+
+    /**
+     * Creates/returns a UuidFactory instance that uses a specific codec
+     * that creates a binary that can be time-ordered
+     *
+     * @return null|UuidFactory
+     */
+    private function getUuidFactory()
+    {
+        if (null === $this->factory) {
+            $this->factory = new UuidFactory();
+        }
+
+        return $this->factory;
+    }
+
+    private function getCodec()
+    {
+        if (null === $this->codec) {
+            $this->codec = new OrderedTimeCodec(
+                $this->getUuidFactory()->getUuidBuilder()
+            );
+        }
+
+        return $this->codec;
+    }
+
+    /**
+     * Using this type only makes sense with Uuid version 1 as this is the only
+     * kind of UUID that can be time-ordered. Passing any other UUID into
+     * this type is likely a mistake
+     *
+     * @param UuidInterface $value
+     * @throws ConversionException
+     */
+    private function assertUuidV1(UuidInterface $value)
+    {
+        if (1 !== $value->getVersion()) {
+            throw ConversionException::conversionFailed(
+                $value->toString(),
+                self::NAME
+            );
+        }
+    }
+
+    private function encode(UuidInterface $uuid)
+    {
+        $this->assertUuidV1($uuid);
+
+        return $this->getCodec()->encodeBinary($uuid);
+    }
+
+    private function decode($bytes)
+    {
+        $decoded = $this->getCodec()->decodeBytes($bytes);
+
+        $this->assertUuidV1($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/UuidBinaryOrderedTimeTypeTest.php
+++ b/tests/UuidBinaryOrderedTimeTypeTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Ramsey\Uuid\Doctrine;
+
+use Doctrine\DBAL\Types\Type;
+use Ramsey\Uuid\Uuid;
+
+class UuidBinaryOrderedTimeTypeTest extends \PHPUnit_Framework_TestCase
+{
+    private $platform;
+
+    /** @var UuidBinaryOrderedTimeType */
+    private $type;
+
+    public static function setUpBeforeClass()
+    {
+        if (class_exists('Doctrine\DBAL\Types\Type')) {
+            Type::addType('uuid_binary_ordered_time', 'Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType');
+        }
+    }
+
+    protected function setUp()
+    {
+        $this->platform = $this->getPlatformMock();
+        $this->platform->expects($this->any())
+            ->method('getBinaryTypeDeclarationSQLSnippet')
+            ->will($this->returnValue('DUMMYBINARY(16)'));
+
+        $this->type = Type::getType('uuid_binary_ordered_time');
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('uuid_binary_ordered_time', $this->type->getName());
+    }
+
+    public function testUuidConvertsToDatabaseValue()
+    {
+        $uuid = Uuid::fromString('ff6f8cb0-c57d-11e1-9b21-0800200c9a66');
+
+        $expected = hex2bin('11e1c57dff6f8cb09b210800200c9a66');
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testStringUuidConvertsToDatabaseValue()
+    {
+        $uuid = 'ff6f8cb0-c57d-11e1-9b21-0800200c9a66';
+
+        $expected = hex2bin('11e1c57dff6f8cb09b210800200c9a66');
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testInvalidUuidConversionForDatabaseValue()
+    {
+        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
+        $this->type->convertToDatabaseValue('abcdefg', $this->platform);
+    }
+
+    public function testNullConversionForDatabaseValue()
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testUuidConvertsToPHPValue()
+    {
+        $uuid = $this->type->convertToPHPValue(hex2bin('11e1c57dff6f8cb09b210800200c9a66'), $this->platform);
+        $this->assertInstanceOf('Ramsey\Uuid\Uuid', $uuid);
+        $this->assertEquals('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
+    }
+
+    public function testInvalidUuidConversionForPHPValue()
+    {
+        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
+        $this->type->convertToPHPValue('abcdefg', $this->platform);
+    }
+
+    public function testUnsupportedUuidConversionToDatabaseValue()
+    {
+        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
+        $this->type->convertToDatabaseValue(Uuid::uuid4(), $this->platform);
+    }
+
+    /**
+     * @dataProvider provideUnsupportedDatabaseValues
+     * @param string $databaseValue
+     */
+    public function testUnsupportedUuidConversionToPHPValue($databaseValue)
+    {
+        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
+        $this->type->convertToPHPValue(hex2bin($databaseValue), $this->platform);
+    }
+
+    public function testNullConversionForPHPValue()
+    {
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testReturnValueIfUuidForPHPValue()
+    {
+        $uuid = Uuid::uuid4();
+        $this->assertSame($uuid, $this->type->convertToPHPValue($uuid, $this->platform));
+    }
+
+    public function testGetGuidTypeDeclarationSQL()
+    {
+        $this->assertEquals('DUMMYBINARY(16)', $this->type->getSqlDeclaration(array('length' => 36), $this->platform));
+    }
+
+    public function testRequiresSQLCommentHint()
+    {
+        $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));
+    }
+
+    private function getPlatformMock()
+    {
+        return $this->getMockBuilder('Doctrine\DBAL\Platforms\AbstractPlatform')
+            ->setMethods(array('getBinaryTypeDeclarationSQLSnippet'))
+            ->getMockForAbstractClass();
+    }
+
+    public function provideUnsupportedDatabaseValues()
+    {
+        $values = [];
+
+        $tail = '1e1c57dff6f8cb09b210800200c9a66';
+        for ($i = 0; $i <= 9; $i++) {
+            if (1 === $i) {
+                continue;
+            }
+            $values["Packed UUID that begins with $i"] = [$i . $tail];
+        }
+
+        return $values;
+    }
+}


### PR DESCRIPTION
This PR attempts to bring feature request #14 to life. 

Since nobody else had volunteered to expose a new codec for UUIDv1 via a Doctrine type, I decided to do so. A Hacktoberfest T-Shirt is not going to win it itself, and neither have I anything else interesting to check out a new supposedly awesome keyboard of mine.

Any feedback is appreciated!

I also expect a couple of questions to be asked, so I'll try to address them in advance.

**— Why didn't you extend `UuidBinaryType`?**
— Liskov Substitution Principle tells us that a subtype should _always_ be able to replace a type it extends. In other words, an inheriting class' instance should be a drop-in replacement for an instance of its parent, which is not the case here as far as I can tell. Hence, extending `UuidBinaryType` would be a misuse of inheritance.

**— Why did you cut off anything else that is not UUIDv1 (and doesn't reprecent one)?**
— It doesn't make sence, does it? Appearing anything else other than UUIDv1 here is likely a result of a mistake; data corruption could accompany such a case. Having an exception is better than trying to do some elaborate insane stuff that messes with one's data, isn't it?

**— There're `@covers` annotations in all other tests, why didn't you add them into yours?**
— To be honest, I didn't find a compelling reason to do so and dropped them to increase signal-to-noise ratio and decrease possible maintetnance burden.
