### PR TITLE
UuidOrderedTimeGenerator: reuse global UuidFactory instead of new'ing it

### DIFF
--- a/src/UuidOrderedTimeGenerator.php
+++ b/src/UuidOrderedTimeGenerator.php
@@ -4,7 +4,7 @@ namespace Ramsey\Uuid\Doctrine;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Ramsey\Uuid\Codec\OrderedTimeCodec;
-use Ramsey\Uuid\UuidFactory;
+use Ramsey\Uuid\Uuid;
 
 class UuidOrderedTimeGenerator extends AbstractIdGenerator
 {
@@ -15,7 +15,7 @@ class UuidOrderedTimeGenerator extends AbstractIdGenerator
 
     public function __construct()
     {
-        $this->factory = new UuidFactory();
+        $this->factory = clone Uuid::getFactory();
 
         $codec = new OrderedTimeCodec(
             $this->factory->getUuidBuilder()


### PR DESCRIPTION
allows UuidFactory to be user-configured

See #36 

Edit: cloning the global factory to avoid unintended side-effects (i.e. modifying its codec - which would prevent from generating both orderedTime and regular uuids)