### PR TITLE
Support PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "jakub-onderka/php-parallel-lint": "^0.9.0",
-        "phpunit/phpunit": "^4.7 || ^5.0",
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4",
         "satooshi/php-coveralls": "^0.6.1",
         "squizlabs/php_codesniffer": "^2.3"
     },

--- a/tests/UuidBinaryOrderedTimeTypeTest.php
+++ b/tests/UuidBinaryOrderedTimeTypeTest.php
@@ -3,9 +3,10 @@
 namespace Ramsey\Uuid\Doctrine;
 
 use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class UuidBinaryOrderedTimeTypeTest extends \PHPUnit_Framework_TestCase
+class UuidBinaryOrderedTimeTypeTest extends TestCase
 {
     private $platform;
 
@@ -54,9 +55,11 @@ class UuidBinaryOrderedTimeTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * @expectedException Doctrine\DBAL\Types\ConversionException
+     */
     public function testInvalidUuidConversionForDatabaseValue()
     {
-        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
         $this->type->convertToDatabaseValue('abcdefg', $this->platform);
     }
 
@@ -72,25 +75,29 @@ class UuidBinaryOrderedTimeTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $uuid->toString());
     }
 
+    /**
+     * @expectedException Doctrine\DBAL\Types\ConversionException
+     */
     public function testInvalidUuidConversionForPHPValue()
     {
-        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
         $this->type->convertToPHPValue('abcdefg', $this->platform);
     }
 
+    /**
+     * @expectedException Doctrine\DBAL\Types\ConversionException
+     */
     public function testUnsupportedUuidConversionToDatabaseValue()
     {
-        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
         $this->type->convertToDatabaseValue(Uuid::uuid4(), $this->platform);
     }
 
     /**
+     * @expectedException Doctrine\DBAL\Types\ConversionException
      * @dataProvider provideUnsupportedDatabaseValues
      * @param string $databaseValue
      */
     public function testUnsupportedUuidConversionToPHPValue($databaseValue)
     {
-        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
         $this->type->convertToPHPValue(hex2bin($databaseValue), $this->platform);
     }
 

--- a/tests/UuidBinaryTypeTest.php
+++ b/tests/UuidBinaryTypeTest.php
@@ -3,9 +3,10 @@ namespace Ramsey\Uuid\Doctrine;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class UuidBinaryTypeTest extends \PHPUnit_Framework_TestCase
+class UuidBinaryTypeTest extends TestCase
 {
     private $platform;
     private $type;
@@ -54,11 +55,11 @@ class UuidBinaryTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException Doctrine\DBAL\Types\ConversionException
      * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToDatabaseValue
      */
     public function testInvalidUuidConversionForDatabaseValue()
     {
-        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
         $this->type->convertToDatabaseValue('abcdefg', $this->platform);
     }
 
@@ -81,11 +82,11 @@ class UuidBinaryTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException Doctrine\DBAL\Types\ConversionException
      * @covers Ramsey\Uuid\Doctrine\UuidBinaryType::convertToPHPValue
      */
     public function testInvalidUuidConversionForPHPValue()
     {
-        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
         $this->type->convertToPHPValue('abcdefg', $this->platform);
     }
 

--- a/tests/UuidGeneratorTest.php
+++ b/tests/UuidGeneratorTest.php
@@ -3,9 +3,10 @@ namespace Ramsey\Uuid\Doctrine;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class UuidGeneratorTest extends \PHPUnit_Framework_TestCase
+class UuidGeneratorTest extends TestCase
 {
     private $em;
     private $entity;

--- a/tests/UuidOrderedTimeGeneratorTest.php
+++ b/tests/UuidOrderedTimeGeneratorTest.php
@@ -2,8 +2,9 @@
 namespace Ramsey\Uuid\Doctrine;
 
 use Doctrine\ORM\Mapping\Entity;
+use PHPUnit\Framework\TestCase;
 
-class UuidOrderedTimeGeneratorTest extends \PHPUnit_Framework_TestCase
+class UuidOrderedTimeGeneratorTest extends TestCase
 {
     /**
      * @var \Ramsey\Uuid\Doctrine\TestEntityManager

--- a/tests/UuidTypeTest.php
+++ b/tests/UuidTypeTest.php
@@ -3,9 +3,10 @@ namespace Ramsey\Uuid\Doctrine;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class UuidTypeTest extends \PHPUnit_Framework_TestCase
+class UuidTypeTest extends TestCase
 {
     private $platform;
     private $type;
@@ -41,11 +42,11 @@ class UuidTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException Doctrine\DBAL\Types\ConversionException
      * @covers Ramsey\Uuid\Doctrine\UuidType::convertToDatabaseValue
      */
     public function testInvalidUuidConversionForDatabaseValue()
     {
-        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
         $this->type->convertToDatabaseValue('abcdefg', $this->platform);
     }
 
@@ -68,11 +69,11 @@ class UuidTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException Doctrine\DBAL\Types\ConversionException
      * @covers Ramsey\Uuid\Doctrine\UuidType::convertToPHPValue
      */
     public function testInvalidUuidConversionForPHPValue()
     {
-        $this->setExpectedException('Doctrine\DBAL\Types\ConversionException');
         $this->type->convertToPHPValue('abcdefg', $this->platform);
     }
 


### PR DESCRIPTION
I added `PHPUnit 6` support.

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02) that support the `PHPUnit\Framework\TestCase` namespace.