### PR TITLE
Update annotations example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,21 @@ type to `uuid`, and defining a custom generator of `Ramsey\Uuid\UuidGenerator`.
 Doctrine will handle the rest.
 
 ``` php
+use Doctrine\ORM\Mapping as ORM;
+
 /**
- * @Entity
- * @Table(name="products")
+ * @ORM\Entity
+ * @ORM\Table(name="products")
  */
 class Product
 {
     /**
      * @var \Ramsey\Uuid\Uuid
      *
-     * @Id
-     * @Column(type="uuid", unique=true)
-     * @GeneratedValue(strategy="CUSTOM")
-     * @CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
+     * @ORM\Id
+     * @ORM\Column(type="uuid", unique=true)
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
      */
     protected $id;
 


### PR DESCRIPTION
Made the annotations more like what you see in an entity that's been generated by the `doctrine:generate:entity` console command. 

This way, the end user won't have to rely on IDE completion to figure out how the `CustomIdGenerator` annotation is namespaced.