### PR TITLE
Handling UuidInterface instances in UuidType::convertToDatabaseValue()

### DIFF
--- a/src/UuidType.php
+++ b/src/UuidType.php
@@ -82,7 +82,7 @@ class UuidType extends Type
         }
         
         if ($value instanceof UuidInterface) {
-            reutn $value->toString();
+            return $value->toString();
         }
 
         if ($value instanceof Uuid || Uuid::isValid($value)) {

--- a/src/UuidType.php
+++ b/src/UuidType.php
@@ -80,6 +80,10 @@ class UuidType extends Type
         if (empty($value)) {
             return null;
         }
+        
+        if ($value instanceof UuidInterface) {
+            reutn $value->toString();
+        }
 
         if ($value instanceof Uuid || Uuid::isValid($value)) {
             return (string) $value;

--- a/tests/UuidTypeTest.php
+++ b/tests/UuidTypeTest.php
@@ -5,6 +5,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DBAL\Mocks\MockPlatform;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 class UuidTypeTest extends TestCase
 {
@@ -39,6 +40,22 @@ class UuidTypeTest extends TestCase
         $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
 
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidType::convertToDatabaseValue
+     */
+    public function testUuidInterfaceConvertsToDatabaseValue()
+    {
+        $uuid = $this->createMock(UuidInterface::class);
+        $uuid
+            ->expects($this->once())
+            ->method('toString')
+            ->willReturn('foo');
+
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals('foo', $actual);
     }
 
     /**


### PR DESCRIPTION
The phpdoc for the method `UuidType::convertToDatabaseValue()` explains it accepts instances of `UuidInterface` however the implementation of the method only handles instances of `Uuid` or `string`s.

This PR handles the case where the value is an instance of `UuidInterface` but is not a `Ramsey\Uuid\Uuid`.