### PR TITLE
Handling UuidInterface instances in UuidType::convertToPHPValue

### DIFF
--- a/src/UuidType.php
+++ b/src/UuidType.php
@@ -56,7 +56,7 @@ class UuidType extends Type
             return null;
         }
 
-        if ($value instanceof Uuid) {
+        if ($value instanceof UuidInterface) {
             return $value;
         }
 

--- a/tests/UuidTypeTest.php
+++ b/tests/UuidTypeTest.php
@@ -90,6 +90,18 @@ class UuidTypeTest extends TestCase
     /**
      * @covers Ramsey\Uuid\Doctrine\UuidType::convertToPHPValue
      */
+    public function testUuidInterfaceConvertsToPHPValue()
+    {
+        $uuid = \Mockery::mock('Ramsey\\Uuid\\UuidInterface');
+
+        $actual = $this->type->convertToPHPValue($uuid, $this->platform);
+
+        $this->assertSame($uuid, $actual);
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Doctrine\UuidType::convertToPHPValue
+     */
     public function testUuidConvertsToPHPValue()
     {
         $uuid = $this->type->convertToPHPValue('ff6f8cb0-c57d-11e1-9b21-0800200c9a66', $this->platform);


### PR DESCRIPTION
The methods `UuidType::convertToDatabaseValue` and `UuidType::convertToPHPValue` should be symetric, but I realize that changes in PR #59 should be present in `UuidType::convertToPHPValue`.