### PR TITLE
Added ParameterType::BINARY to UuidBinaryOrderedTimeType

### DIFF
--- a/src/UuidBinaryOrderedTimeType.php
+++ b/src/UuidBinaryOrderedTimeType.php
@@ -2,6 +2,7 @@
 
 namespace Ramsey\Uuid\Doctrine;
 
+use Doctrine\DBAL\ParameterType;
 use InvalidArgumentException;
 use Ramsey\Uuid\Codec\OrderedTimeCodec;
 use Doctrine\DBAL\Types\ConversionException;
@@ -180,5 +181,15 @@ class UuidBinaryOrderedTimeType extends Type
         $this->assertUuidV1($decoded);
 
         return $decoded;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @return int
+     */
+    public function getBindingType()
+    {
+        return ParameterType::STRING;
     }
 }


### PR DESCRIPTION
By adding this method, we allow Doctrine to set appropriate type for binding UUID parameters in queries. Otherwise they are bound as `ParameterType::STRING` by default. This works in MySQL, but does not in Sqlite, when e.g. running functional tests.