### PR TITLE
Prevent type error while converting invalid value type in `convertToDatabaseValue()`

### DIFF
--- a/src/UuidBinaryOrderedTimeType.php
+++ b/src/UuidBinaryOrderedTimeType.php
@@ -109,7 +109,7 @@ class UuidBinaryOrderedTimeType extends Type
         }
 
         try {
-            if (is_string($value) || method_exists($value, '__toString')) {
+            if (is_string($value) || (is_object($value) && method_exists($value, '__toString'))) {
                 $uuid = $this->getUuidFactory()->fromString((string) $value);
 
                 return $this->encode($uuid);

--- a/src/UuidBinaryType.php
+++ b/src/UuidBinaryType.php
@@ -98,7 +98,7 @@ class UuidBinaryType extends Type
         }
 
         try {
-            if (is_string($value) || method_exists($value, '__toString')) {
+            if (is_string($value) || (is_object($value) && method_exists($value, '__toString'))) {
                 return Uuid::fromString((string) $value)->getBytes();
             }
         } catch (InvalidArgumentException $e) {

--- a/src/UuidType.php
+++ b/src/UuidType.php
@@ -81,7 +81,7 @@ class UuidType extends GuidType
             $value instanceof UuidInterface
             || (
                 (is_string($value)
-                || method_exists($value, '__toString'))
+                || (is_object($value) && method_exists($value, '__toString')))
                 && Uuid::isValid((string) $value)
             )
         ) {

--- a/tests/UuidBinaryOrderedTimeTypeTest.php
+++ b/tests/UuidBinaryOrderedTimeTypeTest.php
@@ -72,6 +72,20 @@ class UuidBinaryOrderedTimeTypeTest extends TestCase
         $this->getType()->convertToDatabaseValue('abcdefg', $this->getPlatform());
     }
 
+    /**
+     * @covers \Ramsey\Uuid\Doctrine\UuidType::convertToDatabaseValue
+     */
+    public function testInvalidValueTypeConversionForDatabaseValue()
+    {
+        if (!method_exists($this, 'expectException')) {
+            $this->markTestSkipped('This version of PHPUnit does not have expectException()');
+        }
+
+        $this->expectException('Doctrine\\DBAL\\Types\\ConversionException');
+
+        $this->getType()->convertToDatabaseValue(false, $this->getPlatform());
+    }
+
     public function testNullConversionForDatabaseValue()
     {
         $this->assertNull($this->getType()->convertToDatabaseValue(null, $this->getPlatform()));

--- a/tests/UuidBinaryTypeTest.php
+++ b/tests/UuidBinaryTypeTest.php
@@ -77,6 +77,20 @@ class UuidBinaryTypeTest extends TestCase
     }
 
     /**
+     * @covers \Ramsey\Uuid\Doctrine\UuidType::convertToDatabaseValue
+     */
+    public function testInvalidValueTypeConversionForDatabaseValue()
+    {
+        if (!method_exists($this, 'expectException')) {
+            $this->markTestSkipped('This version of PHPUnit does not have expectException()');
+        }
+
+        $this->expectException('Doctrine\\DBAL\\Types\\ConversionException');
+
+        $this->getType()->convertToDatabaseValue(false, $this->getPlatform());
+    }
+
+    /**
      * @covers \Ramsey\Uuid\Doctrine\UuidBinaryType::convertToDatabaseValue
      */
     public function testNullConversionForDatabaseValue()

--- a/tests/UuidTypeTest.php
+++ b/tests/UuidTypeTest.php
@@ -95,6 +95,20 @@ class UuidTypeTest extends TestCase
     /**
      * @covers \Ramsey\Uuid\Doctrine\UuidType::convertToDatabaseValue
      */
+    public function testInvalidValueTypeConversionForDatabaseValue()
+    {
+        if (!method_exists($this, 'expectException')) {
+            $this->markTestSkipped('This version of PHPUnit does not have expectException()');
+        }
+
+        $this->expectException('Doctrine\\DBAL\\Types\\ConversionException');
+
+        $this->getType()->convertToDatabaseValue(false, $this->getPlatform());
+    }
+
+    /**
+     * @covers \Ramsey\Uuid\Doctrine\UuidType::convertToDatabaseValue
+     */
     public function testNullConversionForDatabaseValue()
     {
         $this->assertNull($this->getType()->convertToDatabaseValue(null, $this->getPlatform()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
We cannot call `method_exists()` with anything else than `string|object`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
