### PR TITLE
Fix return type

### DIFF
--- a/src/UuidBinaryOrderedTimeType.php
+++ b/src/UuidBinaryOrderedTimeType.php
@@ -54,6 +54,7 @@ class UuidBinaryOrderedTimeType extends Type
      *
      * @param array $fieldDeclaration
      * @param AbstractPlatform $platform
+     * @return string
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {

--- a/src/UuidBinaryType.php
+++ b/src/UuidBinaryType.php
@@ -37,6 +37,7 @@ class UuidBinaryType extends Type
      *
      * @param array $fieldDeclaration
      * @param AbstractPlatform $platform
+     * @return string
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {


### PR DESCRIPTION
Method "Doctrine\DBAL\Types\Type::getSQLDeclaration()" might add "string" as a native return type declaration in the future. Do the same in child class "Ramsey\Uuid\Doctrine\UuidBinaryType" now to avoid errors or add an explicit @return annotation to suppress this message.
