### PR TITLE
Fix return type deprecation warnings

### DIFF
--- a/src/UuidBinaryOrderedTimeType.php
+++ b/src/UuidBinaryOrderedTimeType.php
@@ -71,6 +71,7 @@ class UuidBinaryOrderedTimeType extends Type
      *
      * @param string|UuidInterface|null $value
      * @param AbstractPlatform $platform
+     * @return mixed
      *
      * @throws ConversionException
      */
@@ -96,6 +97,7 @@ class UuidBinaryOrderedTimeType extends Type
      *
      * @param UuidInterface|string|null $value
      * @param AbstractPlatform $platform
+     * @return mixed
      *
      * @throws ConversionException
      */


### PR DESCRIPTION
Similar to https://github.com/ramsey/uuid-doctrine/pull/173
Resolves https://github.com/ramsey/uuid-doctrine/issues/171

#173 only fixes https://github.com/ramsey/uuid-doctrine/issues/171#issuecomment-988066981 but it doesn't fix OP's issue, which is my issue as well.

- Method `Doctrine\DBAL\Types\Type::convertToPHPValue()` might add `mixed` as a native return type declaration in the future. Do the same in child class `Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType` now to avoid errors or add an explicit `@return` annotation to suppress this message.
- Method `Doctrine\DBAL\Types\Type::convertToDatabaseValue()` might add `mixed` as a native return type declaration in the future. Do the same in child class `Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType` now to avoid errors or add an explicit `@return` annotation to suppress this message.