### PR TITLE
Add Mappings php case for php8 attributes and type declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ class Product
 }
 ```
 
-or as follow with [PHP8 attributes](https://www.php.net/manual/fr/language.attributes.overview.php) and [Type declarations](https://www.php.net/manual/en/language.types.declarations.php):
+or, as follows, with [PHP 8 attributes](https://www.php.net/attributes) and [type declarations](https://www.php.net/types.declarations):
 
 ``` php
 use Doctrine\ORM\Mapping as ORM;

--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ class Product
 }
 ```
 
+or as follow with [PHP8 attributes](https://www.php.net/manual/fr/language.attributes.overview.php) and [Type declarations](https://www.php.net/manual/en/language.types.declarations.php):
+
+``` php
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Doctrine\UuidGenerator;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: "products")
+class Product
+{
+    #[ORM\Id]
+    #[ORM\Column(type: "uuid", unique: true)]
+    #[ORM\GeneratedValue(strategy: "CUSTOM")]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    protected UuidInterface|string $id;
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}
+```
+
 If you use the XML Mapping instead of PHP annotations.
 
 ``` xml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
I've only add an example with php type declarations + php8 attributes

## Motivation and context
There is an issue with Doctrine update events triggering if the $id is only type as "string"

## How has this been tested?
I've a PHP8+ApiPlatform project currently, I've faced this issue while testing it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
