### PR TITLE
Adds description on how to configure roave/psr-container-doctrine

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ In Laravel:
     ],
 ```
 
+In [roave/psr-container-doctrine](https://github.com/Roave/psr-container-doctrine):
+
+```php
+<?php
+use Ramsey\Uuid\Doctrine\UuidType;
+
+return [
+    'doctrine' => [
+        'types' => [
+            UuidType::NAME => UuidType::class,
+        ],
+        /* ... */
+    ],
+    /* ... */
+];
+```
+
 ### Mappings
 
 Then, in your models, you may annotate properties by setting the `@Column`


### PR DESCRIPTION
## Description

This PR provides an example on how to use it with [`roave/psr-container-doctrine`](https://github.com/Roave/psr-container-doctrine).

## Motivation and context

Laminas users will most likely utilize `roave/psr-container-doctrine` to integrate doctrine in their projects. The existing Zend Framework configuration is not compatible with it. The added description uses the [psr-container-doctrine full-config example](https://github.com/Roave/psr-container-doctrine/blob/3.6.x/example/full-config.php#L162).

## How has this been tested?

Locally tested. Since it describes the configuration of a third-party library, no tests were added. This change does not affect existing features or behavior.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
