### PR TITLE
Update README to use PHP attributes & add info about postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,62 +94,34 @@ return [
 
 ### Mappings
 
-Then, in your models, you may annotate properties by setting the `@Column`
+Then, in your models, you may annotate properties by setting the `#[Column]`
 type to `uuid`, and defining a custom generator of `Ramsey\Uuid\UuidGenerator`.
 Doctrine will handle the rest.
 
 ``` php
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Doctrine\UuidGenerator;
-
-/**
- * @ORM\Entity
- * @ORM\Table(name="products")
- */
-class Product
-{
-    /**
-     * @var \Ramsey\Uuid\UuidInterface
-     *
-     * @ORM\Id
-     * @ORM\Column(type="uuid", unique=true)
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class=UuidGenerator::class)
-     */
-    protected $id;
-
-    public function getId()
-    {
-        return $this->id;
-    }
-}
-```
-
-or, as follows, with [PHP 8 attributes](https://www.php.net/attributes) and [type declarations](https://www.php.net/types.declarations):
-
-``` php
-use Doctrine\ORM\Mapping as ORM;
-use Ramsey\Uuid\Doctrine\UuidGenerator;
 use Ramsey\Uuid\UuidInterface;
 
+
 #[ORM\Entity]
-#[ORM\Table(name: "products")
+#[ORM\Table(name="products")]
 class Product
 {
     #[ORM\Id]
     #[ORM\Column(type: "uuid", unique: true)]
     #[ORM\GeneratedValue(strategy: "CUSTOM")]
     #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
-    protected UuidInterface|string $id;
+    protected UuidInterface $id;
 
-    public function getId(): string
+    public function getId(): UuidInterface
     {
         return $this->id;
     }
 }
 ```
 
-If you use the XML Mapping instead of PHP annotations.
+If you use the XML Mapping instead of PHP attributes.
 
 ``` xml
 <id name="id" column="id" type="uuid">
@@ -172,7 +144,7 @@ id:
 
 ### Binary database columns
 
-In the previous example, Doctrine will create a database column of type `CHAR(36)`,
+In the previous example, Doctrine will create a database column of type `CHAR(36)` if MariaDB / MySQL are in use,
 but you may also use this library to store UUIDs as binary strings. The
 `UuidBinaryType` helps accomplish this.
 
@@ -198,7 +170,7 @@ doctrine:
 
 Then, when annotating model class properties, use `uuid_binary` instead of `uuid`:
 
-    @Column(type="uuid_binary")
+    #[Column(type: "uuid_binary")]
 
 ### InnoDB-optimised binary UUIDs - deprecated
 
@@ -235,23 +207,17 @@ type to `uuid_binary_ordered_time`, and defining a custom generator of
 `Ramsey\Uuid\UuidOrderedTimeGenerator`. Doctrine will handle the rest.
 
 ``` php
-/**
- * @Entity
- * @Table(name="products")
- */
+#[Entity]
+#[Table(name="products")]´
 class Product
 {
-    /**
-     * @var \Ramsey\Uuid\UuidInterface
-     *
-     * @Id
-     * @Column(type="uuid_binary_ordered_time", unique=true)
-     * @GeneratedValue(strategy="CUSTOM")
-     * @CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidOrderedTimeGenerator")
-     */
-    protected $id;
+    #[Id]
+    #[Column(type: "uuid_binary_ordered_time", unique: true)]
+    #[GeneratedValue(strategy: "CUSTOM")]
+    #[CustomIdGenerator(class: UuidOrderedTimeGenerator::class)]
+    protected UuidInterface $id;
 
-    public function getId()
+    public function getId(): UuidInterface
     {
         return $this->id;
     }
@@ -294,28 +260,22 @@ doctrine:
             # uuid_binary: binary
 ```
 
-Then, in your models, you may annotate properties by setting the `@Column`
+Then, in your models, you may annotate properties by setting the `#[Column]`
 type to `uuid_binary`, and defining a custom generator of
 `Ramsey\Uuid\UuidV7Generator`. Doctrine will handle the rest.
 
 ``` php
-/**
- * @Entity
- * @Table(name="products")
- */
+#[Entity]
+#[Table(name: "products")]
 class Product
 {
-    /**
-     * @var \Ramsey\Uuid\UuidInterface
-     *
-     * @Id
-     * @Column(type="uuid_binary", unique=true)
-     * @GeneratedValue(strategy="CUSTOM")
-     * @CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidV7Generator")
-     */
-    protected $id;
+    #[Id]
+    #[Column(type: "uuid_binary", unique: true)]
+    #[GeneratedValue(strategy: "CUSTOM")]
+    #[CustomIdGenerator(class: UuidV7Generator::class)]
+    protected UuidInterface $id;
 
-    public function getId()
+    public function getId(): UuidInterface
     {
         return $this->id;
     }
@@ -329,6 +289,31 @@ If you use the XML Mapping instead of PHP annotations.
     <generator strategy="CUSTOM"/>
     <custom-id-generator class="Ramsey\Uuid\Doctrine\UuidV7Generator"/>
 </id>
+```
+
+### PostgreSQL considerations
+
+
+If you are using PostgreSQL, Doctrine uses PostgreSQL's `uuid` for the `Ramsey\Uuid\Doctrine\UuidType` (`uuid`).
+Therefor you don't need to use the `uuid_binary` / `uuid_binary_ordered_time` types when using PostgreSQL.
+You can still use `UuidV7Generator::class` to optimize indexing though.
+
+``` php
+#[Entity]
+#[Table(name: "products")]
+class Product
+{
+    #[Id]
+    #[Column(type: "uuid", unique: true)]
+    #[GeneratedValue(strategy: "CUSTOM")]
+    #[CustomIdGenerator(class: UuidV7Generator::class)]
+    protected UuidInterface $id;
+
+    public function getId(): UuidInterface
+    {
+        return $this->id;
+    }
+}
 ```
 
 ### Working with binary identifiers

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ use Ramsey\Uuid\UuidInterface;
 
 
 #[ORM\Entity]
-#[ORM\Table(name="products")]
+#[ORM\Table(name: "products")]
 class Product
 {
     #[ORM\Id]
@@ -208,7 +208,7 @@ type to `uuid_binary_ordered_time`, and defining a custom generator of
 
 ``` php
 #[Entity]
-#[Table(name="products")]´
+#[Table(name: "products")]´
 class Product
 {
     #[Id]


### PR DESCRIPTION
## Description
With PHP 7.X versions not being supported anymore & PHP 8.* all supporting attributes, we can easily upgrade the README to only use attributes. Additionally, I have added some info about PostgreSQL inspired by #225.

As this is a pure documentation change, I removed everything from the issue template as no tests / checks are needed.