### PR TITLE
feat: add support for "doctrine/dbal" 4, drop support for PHP < 8.1, drop support for dbal < 4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -131,10 +131,9 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - "7.4"
-          - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         composer-deps: ["lowest", "highest"]
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "doctrine/dbal": "^2.8 || ^3.0 || ^4.0",
+        "php": "^8.1",
+        "doctrine/dbal": "^4.0",
         "ramsey/uuid": "^3.9.7 || ^4.0"
     },
     "require-dev": {
@@ -29,7 +29,7 @@
         "mockery/mockery": "^1.5",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
-        "phpcsstandards/phpcsutils": "^1.0.0-alpha4",
+        "phpcsstandards/phpcsutils": "^1.0.9",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-mockery": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/dbal": "^2.8 || ^3.0",
+        "doctrine/dbal": "^2.8 || ^3.0 || ^4.0",
         "ramsey/uuid": "^3.9.7 || ^4.0"
     },
     "require-dev": {
         "captainhook/plugin-composer": "^5.3",
-        "doctrine/orm": "^2.5",
+        "doctrine/orm": "^2.5 || ^3.0",
         "ergebnis/composer-normalize": "^2.28.3",
         "mockery/mockery": "^1.5",
         "php-parallel-lint/php-console-highlighter": "^1.0",
@@ -55,11 +55,11 @@
     },
     "config": {
         "allow-plugins": {
+            "captainhook/plugin-composer": true,
             "composer/package-versions-deprecated": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "ergebnis/composer-normalize": true,
-            "phpstan/extension-installer": true,
-            "captainhook/plugin-composer": true
+            "phpstan/extension-installer": true
         },
         "sort-packages": true
     },

--- a/src/UuidBinaryOrderedTimeType.php
+++ b/src/UuidBinaryOrderedTimeType.php
@@ -63,7 +63,7 @@ class UuidBinaryOrderedTimeType extends Type
      *
      * @throws ConversionException
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?UuidInterface
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?UuidInterface
     {
         if ($value instanceof UuidInterface) {
             return $value;
@@ -105,7 +105,7 @@ class UuidBinaryOrderedTimeType extends Type
             // Ignore the exception and pass through.
         }
 
-        throw new ConversionException(self::NAME . ' ' . $value);
+        throw new ConversionException(self::NAME);
     }
 
     public function getName(): string

--- a/src/UuidBinaryOrderedTimeType.php
+++ b/src/UuidBinaryOrderedTimeType.php
@@ -76,7 +76,7 @@ class UuidBinaryOrderedTimeType extends Type
         try {
             return $this->decode($value);
         } catch (Throwable $e) {
-            throw ConversionException::conversionFailed($value, self::NAME);
+            throw new ConversionException(self::NAME . ' ' . $value);
         }
     }
 
@@ -105,7 +105,7 @@ class UuidBinaryOrderedTimeType extends Type
             // Ignore the exception and pass through.
         }
 
-        throw ConversionException::conversionFailed($value, self::NAME);
+        throw new ConversionException(self::NAME . ' ' . $value);
     }
 
     public function getName(): string
@@ -118,7 +118,7 @@ class UuidBinaryOrderedTimeType extends Type
         return true;
     }
 
-    public function getBindingType(): int
+    public function getBindingType(): ParameterType
     {
         return ParameterType::BINARY;
     }
@@ -158,11 +158,7 @@ class UuidBinaryOrderedTimeType extends Type
     {
         /** @psalm-suppress DeprecatedMethod */
         if ($value->getVersion() !== 1) {
-            throw ConversionException::conversionFailedFormat(
-                $value->toString(),
-                self::NAME,
-                self::ASSERT_FORMAT,
-            );
+            throw new ConversionException($value->toString() . ' ' . self::NAME . ' ' . self::ASSERT_FORMAT);
         }
     }
 

--- a/src/UuidBinaryOrderedTimeType.php
+++ b/src/UuidBinaryOrderedTimeType.php
@@ -180,11 +180,7 @@ class UuidBinaryOrderedTimeType extends Type
         try {
             $decoded = $this->getCodec()->decodeBytes($bytes);
         } catch (UnsupportedOperationException $e) {
-            throw ConversionException::conversionFailedFormat(
-                bin2hex($bytes),
-                self::NAME,
-                self::ASSERT_FORMAT,
-            );
+            throw new ConversionException(bin2hex($bytes) . ' ' . self::NAME . ' ' . self::ASSERT_FORMAT);
         }
 
         $this->assertUuidV1($decoded);

--- a/src/UuidBinaryType.php
+++ b/src/UuidBinaryType.php
@@ -54,7 +54,7 @@ class UuidBinaryType extends Type
      *
      * @throws ConversionException
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?UuidInterface
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?UuidInterface
     {
         if ($value instanceof UuidInterface) {
             return $value;
@@ -96,7 +96,7 @@ class UuidBinaryType extends Type
             // Ignore the exception and pass through.
         }
 
-        throw new ConversionException(self::NAME . ' ' . $value);
+        throw new ConversionException(self::NAME);
     }
 
     public function getName(): string

--- a/src/UuidBinaryType.php
+++ b/src/UuidBinaryType.php
@@ -67,7 +67,7 @@ class UuidBinaryType extends Type
         try {
             $uuid = Uuid::fromBytes($value);
         } catch (Throwable $e) {
-            throw ConversionException::conversionFailed($value, self::NAME);
+            throw new ConversionException(self::NAME . ' ' . $value);
         }
 
         return $uuid;
@@ -96,7 +96,7 @@ class UuidBinaryType extends Type
             // Ignore the exception and pass through.
         }
 
-        throw ConversionException::conversionFailed($value, self::NAME);
+        throw new ConversionException(self::NAME . ' ' . $value);
     }
 
     public function getName(): string
@@ -109,7 +109,7 @@ class UuidBinaryType extends Type
         return true;
     }
 
-    public function getBindingType(): int
+    public function getBindingType(): ParameterType
     {
         return ParameterType::BINARY;
     }

--- a/src/UuidGenerator.php
+++ b/src/UuidGenerator.php
@@ -32,12 +32,10 @@ class UuidGenerator extends AbstractIdGenerator
      *
      * @see UuidGenerator::generateId()
      *
-     * @param object | null $entity
-     *
      * @throws Exception
      */
     // phpcs:ignore SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-    public function generate(EntityManagerInterface $em, $entity): UuidInterface
+    public function generate(EntityManagerInterface $em, ?object $entity): UuidInterface
     {
         return Uuid::uuid4();
     }
@@ -45,12 +43,10 @@ class UuidGenerator extends AbstractIdGenerator
     /**
      * Generate an identifier
      *
-     * @param object | null $entity
-     *
      * @throws Exception
      */
     // phpcs:ignore SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-    public function generateId(EntityManagerInterface $em, $entity): UuidInterface
+    public function generateId(EntityManagerInterface $em, ?object $entity): UuidInterface
     {
         return Uuid::uuid4();
     }

--- a/src/UuidOrderedTimeGenerator.php
+++ b/src/UuidOrderedTimeGenerator.php
@@ -62,12 +62,10 @@ class UuidOrderedTimeGenerator extends AbstractIdGenerator
     /**
      * Generates an identifier for an entity.
      *
-     * @param object | null $entity
-     *
      * @throws Exception
      */
     // phpcs:ignore SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-    public function generateId(EntityManagerInterface $em, $entity): UuidInterface
+    public function generateId(EntityManagerInterface $em, ?object $entity): UuidInterface
     {
         return $this->factory->uuid1();
     }

--- a/src/UuidType.php
+++ b/src/UuidType.php
@@ -40,7 +40,7 @@ class UuidType extends GuidType
      *
      * @throws ConversionException
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?UuidInterface
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?UuidInterface
     {
         if ($value instanceof UuidInterface) {
             return $value;
@@ -81,7 +81,7 @@ class UuidType extends GuidType
             return (string) $value;
         }
 
-        throw new ConversionException(self::NAME . ' ' . $value);
+        throw new ConversionException(self::NAME);
     }
 
     public function getName(): string
@@ -95,7 +95,7 @@ class UuidType extends GuidType
     }
 
     /**
-     * @return string[]
+     * @return array<int, string>
      */
     public function getMappedDatabaseTypes(AbstractPlatform $platform): array
     {

--- a/src/UuidType.php
+++ b/src/UuidType.php
@@ -53,7 +53,7 @@ class UuidType extends GuidType
         try {
             $uuid = Uuid::fromString($value);
         } catch (Throwable $e) {
-            throw ConversionException::conversionFailed($value, self::NAME);
+            throw new ConversionException(self::NAME . ' ' . $value);
         }
 
         return $uuid;
@@ -81,7 +81,7 @@ class UuidType extends GuidType
             return (string) $value;
         }
 
-        throw ConversionException::conversionFailed($value, self::NAME);
+        throw new ConversionException(self::NAME . ' ' . $value);
     }
 
     public function getName(): string

--- a/src/UuidV7Generator.php
+++ b/src/UuidV7Generator.php
@@ -42,12 +42,10 @@ class UuidV7Generator extends AbstractIdGenerator
      *
      * @see UuidV7Generator::generateId()
      *
-     * @param object | null $entity*
-     *
      * @throws Exception
      */
     // phpcs:ignore SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-    public function generate(EntityManagerInterface $em, $entity): UuidInterface
+    public function generate(EntityManagerInterface $em, ?object $entity): UuidInterface
     {
         return Uuid::uuid7();
     }
@@ -55,12 +53,10 @@ class UuidV7Generator extends AbstractIdGenerator
     /**
      * Generate an identifier
      *
-     * @param object | null $entity
-     *
      * @throws Exception
      */
     // phpcs:ignore SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-    public function generateId(EntityManagerInterface $em, $entity): UuidInterface
+    public function generateId(EntityManagerInterface $em, ?object $entity): UuidInterface
     {
         return Uuid::uuid7();
     }

--- a/tests/UuidBinaryOrderedTimeTypeTest.php
+++ b/tests/UuidBinaryOrderedTimeTypeTest.php
@@ -47,7 +47,10 @@ class UuidBinaryOrderedTimeTypeTest extends TestCase
 
     public function testGetName(): void
     {
-        $this->assertSame('uuid_binary_ordered_time', $this->getType()->getName());
+        $this->assertSame(
+            'uuid_binary_ordered_time',
+            $this->getType()->lookupName(Type::getType('uuid_binary_ordered_time')),
+        );
     }
 
     public function testUuidConvertsToDatabaseValue(): void
@@ -134,11 +137,6 @@ class UuidBinaryOrderedTimeTypeTest extends TestCase
             'DUMMYBINARY(16)',
             $this->getType()->getSqlDeclaration(['length' => 36], $this->getPlatform()),
         );
-    }
-
-    public function testRequiresSQLCommentHint(): void
-    {
-        $this->assertTrue($this->getType()->requiresSQLCommentHint($this->getPlatform()));
     }
 
     public function testItReturnsAppropriateBindingType(): void

--- a/tests/UuidBinaryOrderedTimeTypeTest.php
+++ b/tests/UuidBinaryOrderedTimeTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ramsey\Uuid\Doctrine;
 
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
@@ -142,6 +143,6 @@ class UuidBinaryOrderedTimeTypeTest extends TestCase
 
     public function testItReturnsAppropriateBindingType(): void
     {
-        $this->assertEquals(16, $this->getType()->getBindingType());
+        $this->assertEquals(ParameterType::BINARY, $this->getType()->getBindingType());
     }
 }

--- a/tests/UuidBinaryTypeTest.php
+++ b/tests/UuidBinaryTypeTest.php
@@ -123,7 +123,7 @@ class UuidBinaryTypeTest extends TestCase
 
     public function testGetName(): void
     {
-        $this->assertSame('uuid_binary', $this->getType()->getName());
+        $this->assertSame('uuid_binary', $this->getType()->lookupName(Type::getType('uuid_binary')));
     }
 
     public function testGetGuidTypeDeclarationSQL(): void
@@ -132,11 +132,6 @@ class UuidBinaryTypeTest extends TestCase
             'DUMMYBINARY(16)',
             $this->getType()->getSqlDeclaration(['length' => 36], $this->getPlatform()),
         );
-    }
-
-    public function testRequiresSQLCommentHint(): void
-    {
-        $this->assertTrue($this->getType()->requiresSQLCommentHint($this->getPlatform()));
     }
 
     public function testItReturnsAppropriateBindingType(): void

--- a/tests/UuidBinaryTypeTest.php
+++ b/tests/UuidBinaryTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ramsey\Uuid\Doctrine;
 
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
@@ -140,6 +141,6 @@ class UuidBinaryTypeTest extends TestCase
 
     public function testItReturnsAppropriateBindingType(): void
     {
-        $this->assertEquals(16, $this->getType()->getBindingType());
+        $this->assertEquals(ParameterType::BINARY, $this->getType()->getBindingType());
     }
 }

--- a/tests/UuidTypeTest.php
+++ b/tests/UuidTypeTest.php
@@ -127,7 +127,7 @@ class UuidTypeTest extends TestCase
 
     public function testGetName(): void
     {
-        $this->assertSame('uuid', $this->getType()->getName());
+        $this->assertSame('uuid', $this->getType()->lookupName(Type::getType('uuid')));
     }
 
     public function testGetGuidTypeDeclarationSQL(): void
@@ -136,11 +136,6 @@ class UuidTypeTest extends TestCase
             'DUMMYVARCHAR()',
             $this->getType()->getSqlDeclaration(['length' => 36], $this->getPlatform()),
         );
-    }
-
-    public function testRequiresSQLCommentHint(): void
-    {
-        $this->assertTrue($this->getType()->requiresSQLCommentHint($this->getPlatform()));
     }
 
     public function testGetMappedDatabaseTypes(): void


### PR DESCRIPTION
## Description
I do not have much knowledge in this topic, but i try to add support for dbal 4 as a new major version, because of BC breaks. 8.1 is needed because of enums.

drop support for PHP < 8.1
drop support for dbal < 4

https://github.com/doctrine/dbal/blob/4.0.0/UPGRADE.md#deprecated-typegetname

I did not found a best practice to migrate this function.
`throw ConversionException::conversionFailedFormat()`


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
